### PR TITLE
fix: 이메일 발송

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -66,8 +66,8 @@ class EmailService:
             if bcc:
                 recipients.extend(bcc)
             
-            # Send email
-            with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
+            # Send email with timeout
+            with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=30) as server:
                 # server.set_debuglevel(1)  # Uncomment for debugging
                 server.starttls()
                 server.login(self.smtp_user, self.smtp_password)


### PR DESCRIPTION
  타임아웃 및 오류 처리 개선

  - SMTP 연결 타임아웃 30초 설정
  - 이메일 발송 실패 시에도 사용자에게 성공 응답
  - 오류는 로그에만 기록하여 사용자 경험 개선